### PR TITLE
Bug fixes and Improvements for efficiency and safety

### DIFF
--- a/cores/arduino/Digital.cpp
+++ b/cores/arduino/Digital.cpp
@@ -23,12 +23,15 @@
  *             INPUT_ANALOG is deprecated and will be removed in a future release.
  */
 void pinMode(pin_size_t pin, PinMode mode) {
+    // Check for invalid pin
     if (pin == NO_PIN) {
         core_debug("Selected pin is not a valid pin number");
         return;
     }
 
+    // Reset pin configuration if already configured
     if (pinConfigManager.isPinConfigured(pin)) {
+        // Stop PWM or DAC if active on this pin
         if (isPinInPinOps(TIMER_PinOps, pin)) {
             pwmStop(pin);
         } else if (isPinInPinOps(DAC_PinOps, pin)) {
@@ -37,6 +40,7 @@ void pinMode(pin_size_t pin, PinMode mode) {
         pinConfigManager.resetPinConfigured(pin);
     }
 
+    // Configure pin based on mode
     switch (mode) {
         case INPUT:
             setPinOp(pin, createPackedPinOps(gpio::Pin_Mode::INPUT_FLOATING, MAX_SPEED, gpio::Pin_Remap_Select::NO_REMAP, 0, 0));
@@ -56,7 +60,7 @@ void pinMode(pin_size_t pin, PinMode mode) {
         // NOTE: INPUT_ANALOG is deprecated.
         // Besides not being part of the Arduino API,
         // it is already handled directly in Analog.cpp
-#pragma GCC diagnostic ignored "-Wswitch"
+        #pragma GCC diagnostic ignored "-Wswitch"
         case INPUT_ANALOG:
             if ((pin != ADC_TEMP) && (pin != ADC_VREF)) {
                 pinOpsPinout(ADC_PinOps, pin);
@@ -83,16 +87,16 @@ void digitalWrite(pin_size_t pin, PinStatus status) {
     if (port == gpio::GPIO_Base::INVALID) {
         return;
     }
-    auto result = gpio::GPIO::get_instance(port);
-    if (result.error() != gpio::GPIO_Error_Type::OK) {
-        return;
-    }
-    auto& instance = result.value();
+
     gpio::Pin_Number pinNum = getPinInPort(pin);
     if (pinNum == gpio::Pin_Number::INVALID) {
         return;
     }
-    instance.write_pin(pinNum, (status != LOW));
+
+    auto result = gpio::GPIO::get_instance(port);
+    if (result.error() == gpio::GPIO_Error_Type::OK) {
+        result.value().write_pin(pinNum, (status != LOW));
+    }
 }
 
 /**
@@ -106,9 +110,22 @@ void digitalWrite(pin_size_t pin, PinStatus status) {
  * @return The current state of the pin as a PinStatus.
  */
 PinStatus digitalRead(pin_size_t pin) {
-    auto result = gpio::GPIO::get_instance(getPortFromPin(pin));
-    auto& instance = result.value();
-    return instance.read_pin(getPinInPort(pin)) ? HIGH : LOW;
+    gpio::GPIO_Base port = getPortFromPin(pin);
+    if (port == gpio::GPIO_Base::INVALID) {
+        return LOW; // Return a default value for invalid port
+    }
+
+    gpio::Pin_Number pinNum = getPinInPort(pin);
+    if (pinNum == gpio::Pin_Number::INVALID) {
+        return LOW; // Return a default value for invalid pin
+    }
+
+    auto result = gpio::GPIO::get_instance(port);
+    if (result.error() != gpio::GPIO_Error_Type::OK) {
+        return LOW; // Return a default value if instance retrieval fails
+    }
+
+    return result.value().read_pin(pinNum) ? HIGH : LOW;
 }
 
 /**
@@ -125,15 +142,14 @@ void digitalToggle(pin_size_t pin) {
     if (port == gpio::GPIO_Base::INVALID) {
         return;
     }
-    auto result = gpio::GPIO::get_instance(port);
-    if (result.error() != gpio::GPIO_Error_Type::OK) {
-        return;
-    }
+
     gpio::Pin_Number pinNum = getPinInPort(pin);
     if (pinNum == gpio::Pin_Number::INVALID) {
         return;
     }
 
-    auto& instance = result.value();
-    instance.toggle_pin(pinNum);
+    auto result = gpio::GPIO::get_instance(port);
+    if (result.error() == gpio::GPIO_Error_Type::OK) {
+        result.value().toggle_pin(pinNum);
+    }
 }

--- a/cores/arduino/ExtiManager.cpp
+++ b/cores/arduino/ExtiManager.cpp
@@ -4,7 +4,6 @@
 
 constexpr uint8_t extiIRQPriority = EXTI_IRQ_PRIORITY;
 constexpr uint8_t extiIRQSubPriority = EXTI_IRQ_SUBPRIORITY;
-constexpr uint8_t maxExtiLines_ = MAX_EXTI_LINES;
 
 ExtiManager& ExtiManager::get_instance() {
     static ExtiManager instance;
@@ -12,30 +11,26 @@ ExtiManager& ExtiManager::get_instance() {
 }
 
 std::array<exti_to_irq, maxExtiLines_> ExtiManager::irq_index {{
-        {0U, EXTI0_IRQn}, {1U, EXTI1_IRQn}, {2U, EXTI2_IRQn}, {3U, EXTI3_IRQn},
-        {4U, EXTI4_IRQn}, {5U, EXTI5_9_IRQn}, {6U, EXTI5_9_IRQn}, {7U, EXTI5_9_IRQn},
-        {8U, EXTI5_9_IRQn}, {9U, EXTI5_9_IRQn}, {10U, EXTI10_15_IRQn}, {11U, EXTI10_15_IRQn},
-        {12U, EXTI10_15_IRQn}, {13U, EXTI10_15_IRQn}, {14U, EXTI10_15_IRQn}, {15U, EXTI10_15_IRQn}
-    }};
+    {0U, EXTI0_IRQn},       {1U, EXTI1_IRQn},       {2U, EXTI2_IRQn},       {3U, EXTI3_IRQn},
+    {4U, EXTI4_IRQn},       {5U, EXTI5_9_IRQn},     {6U, EXTI5_9_IRQn},     {7U, EXTI5_9_IRQn},
+    {8U, EXTI5_9_IRQn},     {9U, EXTI5_9_IRQn},     {10U, EXTI10_15_IRQn},  {11U, EXTI10_15_IRQn},
+    {12U, EXTI10_15_IRQn},  {13U, EXTI10_15_IRQn},  {14U, EXTI10_15_IRQn},  {15U, EXTI10_15_IRQn}
+}};
 
 ExtiManager::ExtiManager() :
     exti_(exti::EXTI::get_instance()),
     callbacks_{nullptr} {}
 
 /**
- * @brief Enable an EXTI interrupt on a specific pin.
+ * @brief Enables an EXTI interrupt on the specified pin.
  *
- * This function enables EXTI interrupts on a given pin. It configures the pin
- * for input and sets the EXTI source in the AFIO. The EXTI interrupt is then
- * enabled and the NVIC priority is set.
+ * This function enables an EXTI interrupt on the specified pin. The pin
+ * must be configured as an input pin and the EXTI source must be set.
+ * The callback function will be called when the EXTI interrupt occurs.
  *
- * @param pin The pin for which to enable the EXTI interrupt
- * @param callback The callback function to be called when the interrupt occurs
- * @param type The type of EXTI interrupt to enable (RISING, FALLING, or BOTH)
- *
- * @note This function configures the pin to be an input pin and sets the EXTI
- * source in the AFIO. The EXTI interrupt is enabled and the NVIC priority is
- * set.
+ * @param pin The pin on which to enable the EXTI interrupt.
+ * @param callback The callback function to call when the EXTI interrupt occurs.
+ * @param type The type of EXTI interrupt to enable (RISING, FALLING, or CHANGE).
  */
 void ExtiManager::enablePinExtiInterrupt(pin_size_t pin, EXTICallback callback, exti::EXTI_Trigger type) {
     gpio::GPIO_Base gpioPort = getPortFromPin(pin);
@@ -43,76 +38,63 @@ void ExtiManager::enablePinExtiInterrupt(pin_size_t pin, EXTICallback callback, 
     if (pinNumber == gpio::Pin_Number::INVALID || gpioPort == gpio::GPIO_Base::INVALID) {
         return;
     }
+
     uint8_t id = static_cast<uint8_t>(pinNumber);
     if (id >= maxExtiLines_) {
         return;
     }
+
+    // Store callback
     callbacks_[id] = callback;
 
+    // Get GPIO instance
     auto portResult = gpio::GPIO::get_instance(gpioPort);
     if (portResult.error() != gpio::GPIO_Error_Type::OK) {
         return;
     }
     auto& instance = portResult.value();
-    gpio::Pin_Mode currentMode = instance.get_pin_mode(pinNumber);
 
     // Use the currently set mode (input) in case user has already configured
     // the pin using the digital pinMode interface.
     //
     // NOTE:
     //  Only input is valid here as only input pins can have an exti
+    gpio::Pin_Mode currentMode = instance.get_pin_mode(pinNumber);
     if (currentMode != gpio::Pin_Mode::INPUT_FLOATING &&
-            currentMode != gpio::Pin_Mode::INPUT_PULLUP &&
-            currentMode != gpio::Pin_Mode::INPUT_PULLDOWN) {
+        currentMode != gpio::Pin_Mode::INPUT_PULLUP &&
+        currentMode != gpio::Pin_Mode::INPUT_PULLDOWN) {
         instance.set_pin_mode(pinNumber, gpio::Pin_Mode::INPUT_FLOATING);
     }
 
-    instance.set_pin_mode(pinNumber, currentMode);
-
-    gpio::Source_Port sourcePort = gpio::Source_Port::INVALID;
-
+    // Map GPIO port to source port
+    gpio::Source_Port sourcePort;
     switch (gpioPort) {
-        case gpio::GPIO_Base::GPIOA_BASE:
-            sourcePort = gpio::Source_Port::SOURCE_IS_GPIOA;
-            break;
-        case gpio::GPIO_Base::GPIOB_BASE:
-            sourcePort = gpio::Source_Port::SOURCE_IS_GPIOB;
-            break;
-        case gpio::GPIO_Base::GPIOC_BASE:
-            sourcePort = gpio::Source_Port::SOURCE_IS_GPIOC;
-            break;
-        case gpio::GPIO_Base::GPIOD_BASE:
-            sourcePort = gpio::Source_Port::SOURCE_IS_GPIOD;
-            break;
+        case gpio::GPIO_Base::GPIOA_BASE: sourcePort = gpio::Source_Port::SOURCE_IS_GPIOA; break;
+        case gpio::GPIO_Base::GPIOB_BASE: sourcePort = gpio::Source_Port::SOURCE_IS_GPIOB; break;
+        case gpio::GPIO_Base::GPIOC_BASE: sourcePort = gpio::Source_Port::SOURCE_IS_GPIOC; break;
+        case gpio::GPIO_Base::GPIOD_BASE: sourcePort = gpio::Source_Port::SOURCE_IS_GPIOD; break;
         case gpio::GPIO_Base::INVALID:
-        default:
-            break;
+        default: return;    // Invalid port
     }
 
-    // Set the source
+    // Configure EXTI
     gpio::AFIO::get_instance().set_exti_source(sourcePort, pinNumber);
-    // Make sure the flag is clear in case of previous use
     exti_.clear_interrupt_flag(static_cast<exti::Interrupt_Flags>(id));
-    // Enable the exti for the pin
     exti_.init(static_cast<exti::EXTI_Line>(id), exti::EXTI_Mode::EXTI_INTERRUPT, type);
 
-    // Set NVIC priority and enable interrupt
-    NVIC_SetPriority(extiToIrq(id), extiIRQPriority);
-    NVIC_EnableIRQ(extiToIrq(id));
+    // Configure NVIC
+    IRQn_Type irq = extiToIrq(id);
+    NVIC_SetPriority(irq, extiIRQPriority);
+    NVIC_EnableIRQ(irq);
 }
 
 /**
- * @brief Disable an EXTI interrupt on a specific pin.
+ * @brief Disable an EXTI interrupt and its NVIC IRQ.
  *
- * This function disables EXTI interrupts on a given pin. It checks if there are
- * any other callbacks registered for the same interrupt line and if so, it
- * doesn't disable the IRQ. If there are no other callbacks, it disables the IRQ.
+ * This function will disable an EXTI interrupt and its NVIC IRQ if there are
+ * no more callbacks registered for the same IRQ.
  *
- * @param pin The pin for which to disable the EXTI interrupt
- *
- * @note This function doesn't set the pin to be an output pin or set the EXTI
- * source in the AFIO. The EXTI interrupt is disabled and the NVIC priority is
- * set.
+ * @param pin The pin to disable the EXTI interrupt for.
  */
 void ExtiManager::disablePinExtiInterrupt(pin_size_t pin) {
     gpio::Pin_Number pinNum = getPinInPort(pin);
@@ -126,33 +108,39 @@ void ExtiManager::disablePinExtiInterrupt(pin_size_t pin) {
     }
 
     callbacks_[id] = nullptr;
-    bool disableIRQ = true;
 
-    // Check for unhandled callbacks first
+    // Get the IRQ for this EXTI line
+    IRQn_Type irq = extiToIrq(id);
+
+    // Check for unhandled callbacks
+    bool disableIRQ = true;
     for (uint8_t i = 0U; i < maxExtiLines_; ++i) {
-        if (extiToIrq(id) == extiToIrq(i) && callbacks_[i] != nullptr) {
+        if (extiToIrq(i) == irq && callbacks_[i] != nullptr) {
             disableIRQ = false;
             break;
         }
     }
 
     if (disableIRQ) {
-        NVIC_DisableIRQ(extiToIrq(id));
+        NVIC_DisableIRQ(irq);
     }
 }
 
 /**
- * @brief Handles an EXTI interrupt and calls the registered callback.
+ * @brief Handle an EXTI interrupt callback.
  *
- * This function takes a Pin_Number and determines the EXTI line and the
- * corresponding callback. It checks if the EXTI flag is set and if so,
- * clears the flag and calls the callback. If the callback is nullptr,
- * nothing is called.
+ * This function is called by the interrupt handlers for EXTI lines 0-15.
+ * It will clear the EXTI interrupt flag and then call the callback
+ * function set for the corresponding pin.
  *
- * @param pin The pin that triggered the EXTI interrupt
+ * @param pin The pin number of the interrupt source.
  */
 void ExtiManager::handleCallback(gpio::Pin_Number pin) {
     uint8_t id = static_cast<uint8_t>(pin);
+    if (id >= maxExtiLines_) {
+        return;
+    }
+
     exti::Interrupt_Flags flag = static_cast<exti::Interrupt_Flags>(id);
     if (exti_.get_interrupt_flag(flag)) {
         exti_.clear_interrupt_flag(flag);
@@ -182,14 +170,14 @@ extern "C" {
         ExtiManager::get_instance().handleCallback(gpio::Pin_Number::PIN_4);
     }
     void EXTI5_9_IRQHandler(void) {
-        for (uint32_t i = static_cast<uint32_t>(gpio::Pin_Number::PIN_5);
-                i <= static_cast<uint32_t>(gpio::Pin_Number::PIN_9); ++i) {
+        for (uint8_t i = static_cast<uint8_t>(gpio::Pin_Number::PIN_5);
+                i <= static_cast<uint8_t>(gpio::Pin_Number::PIN_9); ++i) {
             ExtiManager::get_instance().handleCallback(static_cast<gpio::Pin_Number>(i));
         }
     }
     void EXTI10_15_IRQHandler(void) {
-        for (uint32_t i = static_cast<uint32_t>(gpio::Pin_Number::PIN_10);
-                i <= static_cast<uint32_t>(gpio::Pin_Number::PIN_15); ++i) {
+        for (uint8_t i = static_cast<uint8_t>(gpio::Pin_Number::PIN_10);
+                i <= static_cast<uint8_t>(gpio::Pin_Number::PIN_15); ++i) {
             ExtiManager::get_instance().handleCallback(static_cast<gpio::Pin_Number>(i));
         }
     }

--- a/cores/arduino/ExtiManager.h
+++ b/cores/arduino/ExtiManager.h
@@ -13,7 +13,9 @@
     #define EXTI_IRQ_SUBPRIORITY    0U
 #endif
 
-#define MAX_EXTI_LINES      16
+#define MAX_EXTI_LINES  16
+
+inline constexpr uint8_t maxExtiLines_ = MAX_EXTI_LINES;
 
 struct exti_to_irq {
     uint8_t line_number;
@@ -31,20 +33,17 @@ public:
     void handleCallback(gpio::Pin_Number pin);
 
 private:
-    static std::array<exti_to_irq, MAX_EXTI_LINES> irq_index;
+    static std::array<exti_to_irq, maxExtiLines_> irq_index;
 
     ExtiManager();
 
     exti::EXTI& exti_;
-    EXTICallback callbacks_[MAX_EXTI_LINES];
+    EXTICallback callbacks_[maxExtiLines_];
 
     inline IRQn_Type extiToIrq(uint8_t extiIndex) {
-        for (const auto& index : irq_index) {
-            if (index.line_number == extiIndex) {
-                return index.irq_type;
-            }
+        if (extiIndex < maxExtiLines_) {
+            return irq_index[extiIndex].irq_type;
         }
-        // Return invalid
         return INVALID_IRQ;
     }
 };

--- a/cores/arduino/Interrupts.cpp
+++ b/cores/arduino/Interrupts.cpp
@@ -24,8 +24,8 @@ struct CallbackWrapper {
     void* param;
 };
 
-static CallbackWrapper callbackStorage[MAX_EXTI_LINES];
-static bool usedSlots[MAX_EXTI_LINES] = {false};
+static CallbackWrapper callbackStorage[maxExtiLines_];
+static bool usedSlots[maxExtiLines_] = {false};
 static uint8_t currentSlot = 0U;
 
 /**
@@ -74,7 +74,7 @@ void callbackWrapper(void* param) {
 void attachInterruptParam(pin_size_t pin, voidFuncPtrParam callback, PinStatus mode, void* param) {
     // Find a free slot
     int slotIndex = -1;
-    for (int i = 0; i < static_cast<int>(MAX_EXTI_LINES); i++) {
+    for (int i = 0; i < static_cast<int>(maxExtiLines_); i++) {
         if (!usedSlots[i]) {
             slotIndex = i;
             break;
@@ -138,7 +138,7 @@ void detachInterrupt(pin_size_t pin) {
     ExtiManager::get_instance().disablePinExtiInterrupt(pin);
 
     // Free the used slot
-    for (int i = 0; i < static_cast<int>(MAX_EXTI_LINES); i++) {
+    for (int i = 0; i < static_cast<int>(maxExtiLines_); i++) {
         if (usedSlots[i]) {
             usedSlots[i] = false;
             break;

--- a/cores/arduino/PinConfigManager.hpp
+++ b/cores/arduino/PinConfigManager.hpp
@@ -8,11 +8,8 @@ class PinConfigManager {
 public:
     PinConfigManager() {}
 
-    // Check if the pin is already configured
     bool isPinConfigured(pin_size_t pin);
-    // Mark the pin as configured
     void setPinConfigured(pin_size_t pin);
-    // Reset to unconfigured
     void resetPinConfigured(pin_size_t pin);
 
     uint16_t pinIsConfig[Max_Ports] = {0U};

--- a/cores/arduino/PinOps.cpp
+++ b/cores/arduino/PinOps.cpp
@@ -18,31 +18,35 @@ void setPinOp(pin_size_t pin, uint32_t packedPinOps) {
     if (remap != gpio::Pin_Remap_Select::NO_REMAP) {
         gpio::AFIO::get_instance().set_remap(remap);
     }
+
     gpio::GPIO_Base port = getPortFromPin(pin);
     if (port == gpio::GPIO_Base::INVALID) {
+        core_debug("Invalid port");
         return;
     }
+
     gpio::Pin_Number pinInPort = getPinInPort(pin);
     if (pinInPort == gpio::Pin_Number::INVALID) {
         core_debug("Invalid pin number");
         return;
     }
+
     gpio::Pin_Mode pinMode = getPackedPinMode(packedPinOps);
     if (pinMode == gpio::Pin_Mode::INVALID) {
         core_debug("Invalid pin mode");
         return;
     }
+
     gpio::Output_Speed pinSpeed = getPackedPinSpeed(packedPinOps);
     if (pinSpeed == gpio::Output_Speed::INVALID) {
         core_debug("Invalid output speed");
         return;
     }
+
     auto result = gpio::GPIO::get_instance(port);
-    if (result.error() != gpio::GPIO_Error_Type::OK) {
-        return;
+    if (result.error() == gpio::GPIO_Error_Type::OK) {
+        result.value().set_pin_mode(pinInPort, pinMode, pinSpeed);
     }
-    auto& instance = result.value();
-    instance.set_pin_mode(pinInPort, pinMode, pinSpeed);
 }
 
 /**
@@ -61,22 +65,23 @@ void setPinOp(gpio::GPIO_Base port, gpio::Pin_Number pin, uint32_t packedPinOps)
     if (remap != gpio::Pin_Remap_Select::NO_REMAP) {
         gpio::AFIO::get_instance().set_remap(remap);
     }
+
     gpio::Pin_Mode mode = getPackedPinMode(packedPinOps);
     if (mode == gpio::Pin_Mode::INVALID) {
         core_debug("Invalid pin mode");
         return;
     }
+
     gpio::Output_Speed speed = getPackedPinSpeed(packedPinOps);
     if (speed == gpio::Output_Speed::INVALID) {
         core_debug("Invalid output speed");
         return;
     }
+
     auto result = gpio::GPIO::get_instance(port);
-    if (result.error() != gpio::GPIO_Error_Type::OK) {
-        return;
+    if (result.error() == gpio::GPIO_Error_Type::OK) {
+        result.value().set_pin_mode(pin, mode, speed);
     }
-    auto& instance = result.value();
-    instance.set_pin_mode(pin, mode, speed);
 }
 
 uint32_t portOutputRegister(gpio::GPIO_Base port) {

--- a/cores/arduino/PinOps.hpp
+++ b/cores/arduino/PinOps.hpp
@@ -388,7 +388,7 @@ inline gpio::GPIO portToInstance(gpio::GPIO_Base port) {
  *         GPIO_Base::INVALID if the pin number is invalid.
  */
 inline constexpr gpio::GPIO_Base getPortFromPin(pin_size_t pin) {
-    uint32_t portIndex = static_cast<uint32_t>(pin >> static_cast<uint32_t>(4U));
+    uint32_t portIndex = static_cast<uint32_t>(pin >> 4U);
     if (portIndex >= static_cast<uint32_t>(gpio::GPIO_Base::INVALID)) {
         return gpio::GPIO_Base::INVALID;
     }
@@ -407,8 +407,7 @@ inline constexpr gpio::GPIO_Base getPortFromPin(pin_size_t pin) {
  *         Pin_Number::INVALID if the pin number is invalid.
  */
 inline constexpr gpio::Pin_Number getPinInPort(pin_size_t pin) {
-    uint32_t pinInPort = static_cast<uint32_t>(pin & 0xF);
-
+    uint8_t pinInPort = static_cast<uint8_t>(pin & 0xF);
     if (pinInPort <= 15U) {
         return static_cast<gpio::Pin_Number>(pinInPort);
     }

--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -24,18 +24,20 @@
 
 inline constexpr uint32_t Max_Frequency = 0x0000FFFFU;
 
-struct TimerPinInfo {
+struct TonePinInfo {
     pin_size_t pin;
     int32_t count;
+    gpio::GPIO_Base port;
+    gpio::Pin_Number pinNum;
 };
 
-static TimerPinInfo pinInfo = { NO_PIN, 0 };
+static TonePinInfo pinInfo = { NO_PIN, 0, gpio::GPIO_Base::INVALID, gpio::Pin_Number::INVALID };
 volatile bool destruct_ = false;
 
 static void timerTonePinInit(pin_size_t pin, uint32_t frequency, uint32_t duration);
 static void toneHandler();
 
-GeneralTimer& toneInstance = GeneralTimer::get_instance(static_cast<timer::TIMER_Base>(TIMER_TONE));
+static GeneralTimer& toneInstance = GeneralTimer::get_instance(static_cast<timer::TIMER_Base>(TIMER_TONE));
 
 /**
  * @brief Initializes the timer for generating a tone on a specified pin.
@@ -60,6 +62,11 @@ static void timerTonePinInit(pin_size_t pin, uint32_t frequency, uint32_t durati
     } else if (frequency <= Max_Frequency) {
         pinInfo.pin = pin;
         pinInfo.count = (duration > 0) ? ((toneFreq * duration) / 1000) : -1;
+        pinInfo.port = getPortFromPin(pinInfo.pin);
+        pinInfo.pinNum = getPinInPort(pinInfo.pin);
+        if (pinInfo.port == gpio::GPIO_Base::INVALID || pinInfo.pinNum == gpio::Pin_Number::INVALID) {
+            return;
+        }
 
         setPinOp(pinInfo.pin, createPackedPinOps(
                      gpio::Pin_Mode::OUTPUT_PUSHPULL,
@@ -133,22 +140,22 @@ void noTone(uint8_t pin) {
  * Decrements the pin's count and turns off the pin when the count reaches zero.
  */
 static void toneHandler() {
-    gpio::GPIO_Base port = getPortFromPin(pinInfo.pin);
-    if (port == gpio::GPIO_Base::INVALID) {
+    if (pinInfo.port == gpio::GPIO_Base::INVALID || pinInfo.pinNum == gpio::Pin_Number::INVALID) {
         return;
     }
-    auto& instance = gpio::GPIO::get_instance(port).value();
-    gpio::Pin_Number pinNum = getPinInPort(pinInfo.pin);
-    if (pinNum == gpio::Pin_Number::INVALID) {
+
+    auto result = gpio::GPIO::get_instance(pinInfo.port);
+    if (result.error() != gpio::GPIO_Error_Type::OK) {
         return;
     }
+    auto& instance = result.value();
 
     if (pinInfo.count != 0) {
         if (pinInfo.count > 0) {
             pinInfo.count--;
         }
-        instance.toggle_pin(pinNum);
+        instance.toggle_pin(pinInfo.pinNum);
     } else {
-        instance.write_pin(pinNum, false);
+        instance.write_pin(pinInfo.pinNum, false);
     }
 }

--- a/cores/arduino/UsartSerial.cpp
+++ b/cores/arduino/UsartSerial.cpp
@@ -87,18 +87,17 @@ UsartSerial::UsartSerial(usart::USART_Base Base, pin_size_t rxPin, pin_size_t tx
  *
  * @param baudrate The baudrate to use for this instance.
  * @param config The configuration to use for this instance.
+ * @param useDmaRx True to enable DMA on rx, otherwise false.
  */
-void UsartSerial::begin(unsigned long baudrate, uint16_t config) {
+void UsartSerial::begin(unsigned long baudrate, uint16_t config, bool useDmaRx) {
     if (!(dataTransmitted_[static_cast<size_t>(base_)])) {
         end();
     }
+
     // Configure pins
     configurePins();
 
-    usart::USART_DMA_Config dmaMode = usart::USART_DMA_Config::DMA_NONE;
-#ifdef SERIAL_USE_DMA_RX
-    dmaMode = usart::USART_DMA_Config::DMA_RX;
-#endif
+    usart::USART_DMA_Config dmaMode = useDmaRx ? usart::USART_DMA_Config::DMA_RX : usart::USART_DMA_Config::DMA_NONE;
 
     usart_.init({
         static_cast<uint32_t>(baudrate),
@@ -120,8 +119,8 @@ void UsartSerial::begin(unsigned long baudrate, uint16_t config) {
     // Check DMA config is valid
     checkDmaConfig();
 
-    if (dmaMode == usart::USART_DMA_Config::DMA_NONE) {
-        // Dont prepare receive interrupts if DMA is used
+    // Dont prepare receive interrupts if DMA is used
+    if (!useDmaRx) {
         usart_.prepare_receive_interrupts();
     }
 
@@ -375,17 +374,17 @@ void UsartSerial::configurePins() {
  * exits without making changes.
  */
 void UsartSerial::checkDmaConfig() {
-    if (usart_.get_config().dma_ops == usart::USART_DMA_Config::DMA_NONE) {
+    usart::USART_DMA_Config dmaOps = usart_.get_config().dma_ops;
+    if (dmaOps == usart::USART_DMA_Config::DMA_NONE) {
         return;
     }
 
-    if (usart_.get_config().dma_ops == usart::USART_DMA_Config::DMA_TX ||
-            usart_.get_config().dma_ops == usart::USART_DMA_Config::DMA_DUAL) {
+    if (dmaOps == usart::USART_DMA_Config::DMA_TX || dmaOps == usart::USART_DMA_Config::DMA_DUAL) {
         core_debug("DMA_TX and DMA_DUAL modes are not supported");
         return;
     }
 
-    if (usart_.get_config().dma_ops == usart::USART_DMA_Config::DMA_RX) {
+    if (dmaOps == usart::USART_DMA_Config::DMA_RX) {
         setDmaRxEnable();
     }
 }

--- a/cores/arduino/UsartSerial.hpp
+++ b/cores/arduino/UsartSerial.hpp
@@ -37,7 +37,16 @@ class UsartSerial : public HardwareSerial {
 public:
     static UsartSerial& get_instance(usart::USART_Base Base, pin_size_t rxPin = NO_PIN, pin_size_t txPin = NO_PIN);
 
-    void begin(unsigned long baudrate, uint16_t config) override;
+    void begin(unsigned long baudrate, uint16_t config, bool useDmaRx);
+    inline void begin(unsigned long baudrate, uint16_t config) override {
+        // Temporary compatability with SERIAL_USE_DMA_RX define
+        // Until all users move to the new begin function.
+        bool useDmaRx = false;
+    #ifdef SERIAL_USE_DMA_RX
+        useDmaRx = true;
+    #endif
+        begin(baudrate, config, useDmaRx);
+    }
     inline void begin(unsigned long baudrate) override { begin(baudrate, SERIAL_8N1); }
     void end() override;
     int available() override;

--- a/variants/MFL_AQUILA/variant.h
+++ b/variants/MFL_AQUILA/variant.h
@@ -101,9 +101,8 @@
     #define USER_BTN    PC13
 #endif
 
-#ifndef SERIAL_USE_DMA_RX
-    #define SERIAL_USE_DMA_RX
-#endif
+// Deprecated
+#define SERIAL_USE_DMA_RX
 
 #ifndef ADC_CHANNEL_TEMPSENSOR
     #define ADC_CHANNEL_TEMPSENSOR  16

--- a/variants/MFL_CREALITY_422/variant.h
+++ b/variants/MFL_CREALITY_422/variant.h
@@ -101,9 +101,8 @@
     #define USER_BTN    PC13
 #endif
 
-#ifndef SERIAL_USE_DMA_RX
-    #define SERIAL_USE_DMA_RX
-#endif
+// Deprecated
+#define SERIAL_USE_DMA_RX
 
 #ifndef ADC_CHANNEL_TEMPSENSOR
     #define ADC_CHANNEL_TEMPSENSOR  16

--- a/variants/MFL_CREALITY_422_M3/variant.h
+++ b/variants/MFL_CREALITY_422_M3/variant.h
@@ -101,9 +101,8 @@
     #define USER_BTN    PC13
 #endif
 
-#ifndef SERIAL_USE_DMA_RX
-    #define SERIAL_USE_DMA_RX
-#endif
+// Deprecated
+#define SERIAL_USE_DMA_RX
 
 #ifndef ADC_CHANNEL_TEMPSENSOR
     #define ADC_CHANNEL_TEMPSENSOR  16


### PR DESCRIPTION
Fixes UsartSerial needing a define to enable DMA on Rx pin. Now an overloaded begin function takes a bool set true to enable, false to disable. When the default begin function is used, it is set to false.
Added additional checks to valid ports, pins, and instances. Cached some parameters on frequently used functions for avoid repeated calls, optimized some loops in ExtiManager, added some comments, etc.